### PR TITLE
Use simplified script

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -7,33 +7,16 @@ exports.createLockScript = function(
 ) {
   return new Script([
     Opcode.fromSymbol('type'),
-    Opcode.fromInt(rules.types.UPDATE),
-    Opcode.fromSymbol('equal'),
-    Opcode.fromSymbol('if'),
-    Opcode.fromSymbol('return'),
-    Opcode.fromSymbol('endif'),
-
-    Opcode.fromSymbol('type'),
-    Opcode.fromInt(rules.types.REVOKE),
-    Opcode.fromSymbol('equal'),
-    Opcode.fromSymbol('if'),
-    Opcode.fromSymbol('return'),
-    Opcode.fromSymbol('endif'),
-
-    Opcode.fromSymbol('type'),
-    Opcode.fromInt(rules.types.RENEW),
-    Opcode.fromSymbol('equal'),
-    Opcode.fromSymbol('if'),
-    Opcode.fromSymbol('return'),
-    Opcode.fromSymbol('endif'),
-
-    Opcode.fromSymbol('type'),
     Opcode.fromInt(rules.types.TRANSFER),
     Opcode.fromSymbol('equal'),
+
     Opcode.fromSymbol('if'),
-    Opcode.fromPush(pubKey),
-    Opcode.fromSymbol('checksigverify'),
-    Opcode.fromSymbol('endif'),
-    Opcode.fromInt(1),
+      Opcode.fromPush(pubKey),
+      Opcode.fromSymbol('checksig'),
+    Opcode.fromSymbol('else'),
+      Opcode.fromSymbol('type'),
+      Opcode.fromInt(rules.types.FINALIZE),
+      Opcode.fromSymbol('equal'),
+    Opcode.fromSymbol('endif')
   ]);
 }

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -12,7 +12,7 @@ describe('script.js', () => {
       const lockScript = createLockScript(Buffer.from(address.publicKey, 'hex'));
       assert.equal(
         lockScript.toString(),
-        `OP_TYPE OP_7 OP_EQUAL OP_IF OP_RETURN OP_ENDIF OP_TYPE OP_11 OP_EQUAL OP_IF OP_RETURN OP_ENDIF OP_TYPE OP_8 OP_EQUAL OP_IF OP_RETURN OP_ENDIF OP_TYPE OP_9 OP_EQUAL OP_IF 0x21 0x${address.publicKey} OP_CHECKSIGVERIFY OP_ENDIF OP_1`,
+        `OP_TYPE OP_9 OP_EQUAL OP_IF 0x21 0x${address.publicKey} OP_CHECKSIG OP_ELSE OP_TYPE OP_10 OP_EQUAL OP_ENDIF`,
       );
     });
   });

--- a/test/swapService.test.js
+++ b/test/swapService.test.js
@@ -131,7 +131,7 @@ describe('finalizeNameLock', () => {
 
     assert.throws(() => {
       mtx.checkInput(0, coin, ANYONECANPAY | SINGLEREVERSE);
-    }, `OP_RETURN (op=OP_RETURN, ip=${ip})`);
+    }, `EVAL_FALSE`);
   }
 
   beforeEach(async () => {


### PR DESCRIPTION
Closes #2 

This also makes me think the auction presigns should include a protocol version number.

For example, if you merge this PR, it will break compatibility with existing users because `swapProof.verify()` checks for the exact script.