### PR TITLE
context: add nodeApiKey param

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -8,7 +8,8 @@ class Context {
     walletId,
     apiKey,
     passphraseGetter = noopPassphraseGetter,
-    host = '127.0.0.1'
+    host = '127.0.0.1',
+    optionalNodeApiKey,
   ) {
     this.networkName = networkName;
     this.network = Network.get(networkName);
@@ -16,12 +17,12 @@ class Context {
     this.nodeClient = new NodeClient({
       port: this.network.rpcPort,
       host,
-      apiKey,
+      apiKey: optionalNodeApiKey || apiKey,
     });
     this.walletClient = new WalletClient({
       port: this.network.walletPort,
       host,
-      apiKey,
+      apiKey: apiKey,
     });
     this.wallet = this.walletClient.wallet(walletId);
     this.passphraseGetter = passphraseGetter;

--- a/src/context.js
+++ b/src/context.js
@@ -9,7 +9,7 @@ class Context {
     apiKey,
     passphraseGetter = noopPassphraseGetter,
     host = '127.0.0.1',
-    optionalNodeApiKey,
+    nodeApiKey,
   ) {
     this.networkName = networkName;
     this.network = Network.get(networkName);
@@ -17,7 +17,7 @@ class Context {
     this.nodeClient = new NodeClient({
       port: this.network.rpcPort,
       host,
-      apiKey: optionalNodeApiKey || apiKey,
+      apiKey: nodeApiKey || apiKey,
     });
     this.walletClient = new WalletClient({
       port: this.network.walletPort,


### PR DESCRIPTION
@kurumiimari I think it might be better to directly pass in a `nodeClient` and `walletClient` instance eventually. In the future there might be hosted node api that does not follow the same `host + port` configuration as `hsd`.